### PR TITLE
Fix quantity field in Quiz Generator

### DIFF
--- a/src/components/QuizGenerator.tsx
+++ b/src/components/QuizGenerator.tsx
@@ -13,6 +13,10 @@ export const QuizGenerator: React.FC<QuizGeneratorProps> = ({ onQuizGenerated })
   const [numberOfQuestions, setNumberOfQuestions] = useState(5);
   const [isLoading, setIsLoading] = useState(false);
 
+  const removeLeadingZeros = (value: string) => {
+    return value.replace(/^0+/, '');
+  };
+
   const handleGenerateQuiz = async () => {
     setIsLoading(true);
     try {
@@ -87,7 +91,7 @@ export const QuizGenerator: React.FC<QuizGeneratorProps> = ({ onQuizGenerated })
           <input
             type="number"
             value={numberOfQuestions}
-            onChange={(e) => setNumberOfQuestions(Number(e.target.value))}
+            onChange={(e) => setNumberOfQuestions(Number(removeLeadingZeros(e.target.value)))}
             min="1"
             max="20"
             className="w-full p-2 rounded-md border border-input bg-background text-foreground focus:ring-2 focus:ring-primary focus:border-primary"

--- a/src/components/QuizGenerator.tsx
+++ b/src/components/QuizGenerator.tsx
@@ -14,7 +14,7 @@ export const QuizGenerator: React.FC<QuizGeneratorProps> = ({ onQuizGenerated })
   const [isLoading, setIsLoading] = useState(false);
 
   const removeLeadingZeros = (value: string) => {
-    return value.replace(/^0+/, '');
+    return value.replace(/^0+/, '') || '1';
   };
 
   const handleGenerateQuiz = async () => {


### PR DESCRIPTION
Remove leading zeros from the quantity field in the quiz generator.

* Add a `removeLeadingZeros` function to handle leading zeros in the input value.
* Modify the `onChange` event handler of the number input field to use the `removeLeadingZeros` function before updating the `numberOfQuestions` state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nemuba/quiz-game/pull/1?shareId=5804e35f-1088-4f7e-838a-0f8e1ac989c3).